### PR TITLE
Bugfix: Handle non-existent 'filename' key in TVDB data.

### DIFF
--- a/resources/lib/meta_info.py
+++ b/resources/lib/meta_info.py
@@ -229,7 +229,7 @@ def get_episode_metadata_tvdb(season_metadata, episode, banners=True):
 	info['votes'] = episode.get('ratingcount','')
 	info['mediatype'] = 'episode'
 	if banners:
-		info['poster'] = episode['filename']
+		info['poster'] = episode.get('filename', '')
 	return info
 
 def get_episode_metadata_tmdb(season_metadata, episode):


### PR DESCRIPTION
Logic to handle empty data returned by TVDB in #53 leaves it possible for this
key to be empty. For some reason this key alone was always assumed to exist
by this consumer. Use `dict.get()` method as is used to access other attributes
in this function.